### PR TITLE
Functionality to take items from SQS and save to db

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,5 @@
 NODE_ENV=development
 AWS_DEFAULT_REGION=eu-west-1
-SNS_AVAILABILITY_HISTORY_TOPIC_NAME=hvt-sns-availability-history-topic
-SQS_AVAILABILITY_HISTORY_QUEUE_URL=http://host.docker.internal:8800/000000000000/hvt-availability-history-sqs
+SQS_AVAILABILITY_HISTORY_QUEUE_URL=http://host.docker.internal:8000/000000000000/hvt-availability-history-sqs
+DYNAMO_URL=http://host.docker.internal:8000
+TABLE_NAME=AvailabilityHistory

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
 NODE_ENV=development
-AWS_DEFAULT_REGION=eu-west-1
+REGION=eu-west-1
 DYNAMO_URL=http://host.docker.internal:8000
 TABLE_NAME=AvailabilityHistory

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
 NODE_ENV=development
 AWS_DEFAULT_REGION=eu-west-1
-SQS_AVAILABILITY_HISTORY_QUEUE_URL=http://host.docker.internal:8000/000000000000/hvt-availability-history-sqs
 DYNAMO_URL=http://host.docker.internal:8000
 TABLE_NAME=AvailabilityHistory

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,8 +8,5 @@
         "alwaysTryTypes": true
       }
     }
-  },
-  "rules": {
-    "max-len": ["error", { "code": 120 }] // Set default max line length
   }
 }

--- a/events/event.json
+++ b/events/event.json
@@ -1,36 +1,16 @@
 {
-  "Records": [
-      {
-          "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
-          "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
-          "body": "Test message.",
-          "attributes": {
-              "ApproximateReceiveCount": "1",
-              "SentTimestamp": "1545082649183",
-              "SenderId": "AIDAIENQZJOLO23YVJ4VO",
-              "ApproximateFirstReceiveTimestamp": "1545082649185"
-          },
-          "messageAttributes": {},
-          "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
-          "eventSource": "aws:sqs",
-          "eventSourceARN": "arn:aws:sqs:eu-west-1:000000000000:hvt-availability-history-sqs",
-          "awsRegion": "eu-west-1"
-      },
-      {
-          "messageId": "2e1424d4-f796-459a-8184-9c92662be6da",
-          "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
-          "body": "Test message.",
-          "attributes": {
-              "ApproximateReceiveCount": "1",
-              "SentTimestamp": "1545082650636",
-              "SenderId": "AIDAIENQZJOLO23YVJ4VO",
-              "ApproximateFirstReceiveTimestamp": "1545082650649"
-          },
-          "messageAttributes": {},
-          "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
-          "eventSource": "aws:sqs",
-          "eventSourceARN": "arn:aws:sqs:eu-west-1:000000000000:hvt-availability-history-sqs",
-          "awsRegion": "eu-west-1"
-      }
-  ]
+    "Records": [
+        {
+            "messageId": "4f80239a-03c9-4fce-d68a-104001cbc5cb",
+            "receiptHandle": "gvjxhsgayqxjneypkfnbfyvnvoeajirwkwlgmoioigyqijuqaembinhjsrkpaxvyhpgrkkzfoadwmttnqmcexwougjbuhhikmkiuxnzeqhzkwtwfacjdmmlcwdtmgkhytlmapuodsxewfqfkfyabwypmwabrgneyzqdfzstnzdrsdhpfzygvtzbhh",
+            "mD5OfBody": "fb4823f6e5532530878d696331b20f3c",
+            "body": "{\"Type\": \"Notification\", \"MessageId\": \"b5c987c9-508b-416d-aff9-38fd81c4fb73\", \"Token\": null, \"TopicArn\": \"topicarn\", \"Message\": \"{\\\"id\\\":\\\"7db12eed-0c3f-4d27-8221-5699f4e3ea22\\\",\\\"name\\\":\\\"Test Cars Ltd.\\\",\\\"email\\\":\\\"hello@email.com\\\",\\\"availability\\\":{\\\"isAvailable\\\":false,\\\"lastUpdated\\\":\\\"2020-10-09T12:31:46.518Z\\\",\\\"endDate\\\":\\\"2020-11-03T14:21:45.000Z\\\",\\\"startDate\\\":\\\"2020-10-06T14:21:45.000Z\\\"},\\\"token\\\":\\\"eyJhbGciOiJIUzI1Ni\\\"}\", \"SubscribeURL\": null, \"Timestamp\": \"2021-03-25T11:41:45.511Z\", \"SignatureVersion\": \"1\", \"Signature\": \"EXAMPLEpH+..\", \"SigningCertURL\": \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem\", \"Subject\": \"New AvailabilityHistory message sent to SNS\"}",
+            "attributes": {
+                "SenderId": "AIDAIT2UOQQY3AUEKVGXU",
+                "SentTimestamp": "1616672505599",
+                "ApproximateReceiveCount": "1",
+                "ApproximateFirstReceiveTimestamp": "1616672530339"
+            }
+        }
+    ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,5 @@ module.exports = {
       lines: 75,
       statements: 75
     }
-  },
-  automock: true,
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -564,6 +564,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -868,6 +881,24 @@
         "rimraf": "^3.0.2"
       }
     },
+    "@sideway/address": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -887,9 +918,9 @@
       }
     },
     "@types/aws-lambda": {
-      "version": "8.10.72",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.72.tgz",
-      "integrity": "sha512-jOrTwAhSiUtBIN/QsWNKlI4+4aDtpZ0sr2BRvKW6XQZdspgHUSHPcuzxbzCRiHUiDQ+0026u5TSE38VyIhNnfA==",
+      "version": "8.10.73",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.73.tgz",
+      "integrity": "sha512-P+a6TRQbRnVQOIjWkmw6F23wiJcF+4Uniasbzx7NAXjLQCVGx/Z4VoMfit81/pxlmcXNxAMGuYPugn6CrJLilQ==",
       "dev": true
     },
     "@types/babel__core": {
@@ -976,9 +1007,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.21",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.21.tgz",
-      "integrity": "sha512-ab9TyM/69yg7eew9eOwKMUmvIZAKEGZYlq/dhe5/0IMUd/QLJv5ldRMdddSn+u22N13FP3s5jYyktxuBwY0kDA==",
+      "version": "26.0.22",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
+      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
@@ -1019,6 +1050,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "@types/yargs": {
@@ -1740,9 +1777,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.869.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.869.0.tgz",
-      "integrity": "sha512-Sj9H+OH1sizBJt6WyTFBvCthZ1hRNUi4qRFO922agf+cOfmq1r+PYLOcG/0qgLMe2aelRwfT2qE2AZ97mADiOw==",
+      "version": "2.873.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.873.0.tgz",
+      "integrity": "sha512-pww0ImyviDpBDbD2Tj+OyIcSuBKoC7g1g6IzMIFlbWSjbz4WWX46IwZ6jRMy2zGcbEpkl7FjI+s1E7tV9Pcjgg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -5919,6 +5956,18 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "joi": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint '*/**/*.ts' --quiet --fix",
     "lint:ci": "eslint '*/**/*.ts'",
-    "test": "jest --coverage",
+    "test": "jest --coverage tests",
     "test:ci": "jest --ci",
     "build:dev": "webpack-cli --config webpack.development.js",
     "watch:dev": "webpack-cli --config webpack.development.watch.js",
@@ -20,15 +20,17 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.869.0",
-    "dotenv": "^8.2.0"
+    "aws-sdk": "^2.873.0",
+    "dotenv": "^8.2.0",
+    "joi": "^17.4.0"
   },
   "devDependencies": {
     "@dvsa/eslint-config-ts": "^2.0.0",
-    "@types/aws-lambda": "^8.10.72",
+    "@types/aws-lambda": "^8.10.73",
     "@types/dotenv": "^8.2.0",
-    "@types/jest": "^26.0.21",
+    "@types/jest": "^26.0.22",
     "@types/node": "^12.20.6",
+    "@types/uuid": "^8.3.0",
     "archiver": "^5.3.0",
     "aws-sam-webpack-plugin": "^0.6.0",
     "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -1,21 +1,37 @@
 import 'dotenv/config';
 import type { Context, SQSEvent } from 'aws-lambda';
-import { getConfig } from '../lib/config';
-import handle from '../util/handle-await-error';
 import { createLogger, Logger } from '../util/logger';
+import * as dynamodb from '../service/dynamodb.service';
+import { parsePayload } from '../util/import-data';
 
 export const handler = async (event: SQSEvent, context: Context): Promise<void> => {
   const logger: Logger = createLogger(null, context);
   logger.info('History SQS lambda triggered.');
 
-  const config = getConfig();
+  const promises = event.Records.map((record) => {
+    logger.debug(`Processing record: ${JSON.stringify(record.attributes)}`);
+    let item: Record<string, unknown>;
 
-  // Loop through each record
-  const records = event.Records;
-  records.forEach((record) => {
-    // Do stuff with record
-    logger.debug(`Processing record: ${JSON.stringify(record)}`);
+    try {
+      item = parsePayload(record.body);
+    } catch (err) {
+      return { result: 'failure' };
+    }
+
+    return dynamodb.create(item)
+      .then(() => ({ id: item.id, result: 'success' }))
+      .catch(() => ({ id: item.id, result: 'failure' }));
   });
 
-  logger.info('History SQS lambda done.');
+  const results = await Promise.all(promises);
+
+  const successful = results.filter((job) => job.result === 'success');
+  const failed = results.filter((job) => job.result === 'failure');
+
+  if (failed.length > 0) {
+    logger.warn(`Queue item failed: Could not update the following items: ${failed.join(', ')}`);
+  }
+
+  logger.info(`History queue done. Total items processed: ${promises.length}, \
+ successful: ${successful.length}, failed: ${failed.length}.`);
 };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,6 @@
 interface Config {
   awsRegion: string,
   nodeEnv: string,
-  sqsAvailabilityHistoryQueueUrl: string,
   dynamoUrl: string,
   tableName: string,
 }
@@ -10,7 +9,6 @@ export const getConfig = (): Config => {
   [
     'AWS_DEFAULT_REGION',
     'NODE_ENV',
-    'SQS_AVAILABILITY_HISTORY_QUEUE_URL',
     'DYNAMO_URL',
     'TABLE_NAME',
   ].forEach((envVar) => {
@@ -21,7 +19,6 @@ export const getConfig = (): Config => {
   return {
     awsRegion: process.env.AWS_DEFAULT_REGION,
     nodeEnv: process.env.NODE_ENV,
-    sqsAvailabilityHistoryQueueUrl: process.env.SQS_AVAILABILITY_HISTORY_QUEUE_URL,
     dynamoUrl: process.env.DYNAMO_URL,
     tableName: process.env.TABLE_NAME,
   };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,16 +1,18 @@
 interface Config {
   awsRegion: string,
   nodeEnv: string,
-  snsAvailabilityHistoryTopicName: string,
-  sqsAvailabilityHistoryQueueUrl: string
+  sqsAvailabilityHistoryQueueUrl: string,
+  dynamoUrl: string,
+  tableName: string,
 }
 
 export const getConfig = (): Config => {
   [
     'AWS_DEFAULT_REGION',
     'NODE_ENV',
-    'SNS_AVAILABILITY_HISTORY_TOPIC_NAME',
-    'SQS_AVAILABILITY_HISTORY_QUEUE_URL'
+    'SQS_AVAILABILITY_HISTORY_QUEUE_URL',
+    'DYNAMO_URL',
+    'TABLE_NAME',
   ].forEach((envVar) => {
     if (!process.env[`${envVar}`]) {
       throw new Error(`Environment variable ${envVar} seems to be missing.`);
@@ -19,7 +21,8 @@ export const getConfig = (): Config => {
   return {
     awsRegion: process.env.AWS_DEFAULT_REGION,
     nodeEnv: process.env.NODE_ENV,
-    snsAvailabilityHistoryTopicName: process.env.SNS_AVAILABILITY_HISTORY_TOPIC_NAME,
-    sqsAvailabilityHistoryQueueUrl: process.env.SQS_AVAILABILITY_HISTORY_QUEUE_URL
+    sqsAvailabilityHistoryQueueUrl: process.env.SQS_AVAILABILITY_HISTORY_QUEUE_URL,
+    dynamoUrl: process.env.DYNAMO_URL,
+    tableName: process.env.TABLE_NAME,
   };
 };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,7 +7,7 @@ interface Config {
 
 export const getConfig = (): Config => {
   [
-    'AWS_DEFAULT_REGION',
+    'REGION',
     'NODE_ENV',
     'DYNAMO_URL',
     'TABLE_NAME',
@@ -17,7 +17,7 @@ export const getConfig = (): Config => {
     }
   });
   return {
-    awsRegion: process.env.AWS_DEFAULT_REGION,
+    awsRegion: process.env.REGION,
     nodeEnv: process.env.NODE_ENV,
     dynamoUrl: process.env.DYNAMO_URL,
     tableName: process.env.TABLE_NAME,

--- a/src/lib/import-data.ts
+++ b/src/lib/import-data.ts
@@ -1,8 +1,8 @@
 import { v4 } from 'uuid';
 
-type HistoryData = {'id': string, 'atfId': string, 'token'?: string };
+export type HistoryData = {'id': string, 'atfId': string, 'token'?: string };
 
-export const parsePayload = (requestBody: string): Record<string, unknown> => {
+export const parsePayload = (requestBody: string): HistoryData => {
   try {
     const body : Record<string, string> = <Record<string, string>> JSON.parse(requestBody);
     const message : Record<string, string> = <Record<string, string>> JSON.parse(body.Message);

--- a/src/service/dynamodb.service.ts
+++ b/src/service/dynamodb.service.ts
@@ -1,0 +1,19 @@
+import { DynamoDB } from 'aws-sdk';
+import { PutItemOutput } from 'aws-sdk/clients/dynamodb';
+import { getConfig } from '../lib/config';
+
+const config = getConfig();
+const { tableName } = config;
+
+const client = new DynamoDB.DocumentClient({
+  endpoint: config.dynamoUrl,
+  region: config.awsRegion,
+});
+
+export const create = async (item: Record<string, unknown>): Promise<PutItemOutput> => {
+  const params = {
+    Item: item,
+    TableName: tableName,
+  };
+  return client.put(params).promise();
+};

--- a/src/util/import-data.ts
+++ b/src/util/import-data.ts
@@ -1,0 +1,26 @@
+import { v4 } from 'uuid';
+
+type HistoryData = {'id': string, 'atfId': string, 'token'?: string };
+
+export const parsePayload = (requestBody: string): Record<string, unknown> => {
+  try {
+    const body : Record<string, string> = <Record<string, string>> JSON.parse(requestBody);
+    const message : Record<string, string> = <Record<string, string>> JSON.parse(body.Message);
+    const historyData = message as HistoryData;
+
+    if (!historyData.id) {
+      throw new Error('missing id');
+    }
+
+    historyData.atfId = historyData.id;
+    historyData.id = v4();
+
+    // delete the token for security - why bother keeping it?
+    delete historyData.token;
+
+    return historyData;
+  } catch (err) {
+    const errorMsg: string = <string> err || '';
+    throw new Error(`Unable to parse request body. ${errorMsg}`);
+  }
+};

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,10 +1,10 @@
-import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import type { Context } from 'aws-lambda';
 
 export class Logger {
   logFormat: string;
 
-  constructor(apiRequestId: string, correlationId: string) {
-    this.logFormat = `{ "apiRequestId": "${apiRequestId}", "correlationId": "${correlationId}", "message": "%s" }`;
+  constructor(apiRequestId: string) {
+    this.logFormat = `{ "apiRequestId": "${apiRequestId}", "message": "%s" }`;
   }
 
   public debug(msg: string): void {
@@ -24,10 +24,7 @@ export class Logger {
   }
 }
 
-export const createLogger = (event: APIGatewayProxyEvent, context: Context): Logger => {
+export const createLogger = (context: Context): Logger => {
   const lambdaRequestId: string = context.awsRequestId;
-  const apiRequestId: string = event?.requestContext.requestId;
-  const correlationId: string = event?.headers['X-Correlation-Id'] || lambdaRequestId;
-
-  return new Logger(apiRequestId, correlationId);
+  return new Logger(lambdaRequestId);
 };

--- a/template.yml
+++ b/template.yml
@@ -5,6 +5,7 @@ Resources:
   SQSHistoryFunction:
     Type: 'AWS::Serverless::Function'
     Properties:
+      Timeout: 30
       CodeUri: src/handler/
       Handler: index.handler
       Runtime: nodejs12.x

--- a/tests/handler/index.test.ts
+++ b/tests/handler/index.test.ts
@@ -7,6 +7,15 @@ import * as mocks from '../mocks/validRecord';
 import { getExpectedEventItem } from '../mocks/validParsedRecord';
 import * as dynamodb from '../../src/service/dynamodb.service';
 
+jest.mock('../../src/lib/config', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    awsRegion: 'region',
+    nodeEnv: 'nodeEnd',
+    dynamoUrl: 'dynamoUrl',
+    tableName: 'tableName',
+  }),
+}));
+
 describe('Availability history lambda index tests', () => {
   let eventMock: SQSEvent;
   let contextMock: Context;

--- a/tests/handler/index.test.ts
+++ b/tests/handler/index.test.ts
@@ -1,0 +1,71 @@
+import type { Context, SQSEvent } from 'aws-lambda';
+import { PutItemOutput } from 'aws-sdk/clients/dynamodb';
+import { handler } from '../../src/handler';
+import * as importData from '../../src/lib/import-data';
+import * as logger from '../../src/util/logger';
+import { getValidRecord } from '../mocks/validRecord';
+import { getExpectedEventItem } from '../mocks/validParsedRecord';
+import * as dynamodb from '../../src/service/dynamodb.service';
+
+describe('Availability history lambda index tests', () => {
+  let eventMock: SQSEvent;
+  let contextMock: Context;
+  const loggerInfoSpy = jest.fn();
+  const loggerErrorSpy = jest.fn();
+  const validRecord = {
+    messageId: '4f80239a-03c9-4fce-d68a-104001cbc5cb',
+    receiptHandle: 'gvjxhsgayqxjneypkfnbfyvnvoeajirwkwlgmoioigyqijuqaembinhjsrkpaxvyhp',
+    mD5OfBody: 'fb4823f6e5532530878d696331b20f3c',
+    // eslint-disable-next-line max-len
+    body: '{"Type": "Notification", "MessageId": "baff9", "Token": null, "TopicArn": "topicarn", "Message": "message body", "SigningCertURL": "https://sns.us-east-1..com/SimpleNotificationService-.pem", "Subject": "New AvailabilityHistory message sent to SNS"}',
+    attributes: {
+      SenderId: 'AIDAIT2UOQQY3AUEKVGXU',
+      SentTimestamp: '1616672505599',
+      ApproximateReceiveCount: '1',
+      ApproximateFirstReceiveTimestamp: '1616672530339',
+    },
+  };
+
+  beforeAll(() => {
+    contextMock = <Context> {};
+
+    jest.spyOn(logger, 'createLogger').mockReturnValue(<logger.Logger> <unknown> {
+      debug: jest.fn(),
+      info: loggerInfoSpy,
+      warn: jest.fn(),
+      error: loggerErrorSpy,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should complete successfully if no errors', async () => {
+    jest.spyOn(importData, 'parsePayload').mockReturnValue(getExpectedEventItem('456-456-456'));
+    jest.spyOn(dynamodb, 'create').mockReturnValue(Promise.resolve(<PutItemOutput>{ id: '456-456-456' }));
+
+    eventMock = <SQSEvent> <unknown>{
+      Records: [getValidRecord()],
+    };
+    await handler(eventMock, contextMock);
+
+    expect(loggerInfoSpy).toHaveBeenCalledTimes(2);
+    expect(loggerInfoSpy).nthCalledWith(2, 'History queue finished processing. Total items processed: 1, successful: 1, failed: 0.');
+  });
+
+  test('should log out error if problem parsing input data', async () => {
+    jest.spyOn(importData, 'parsePayload').mockImplementation(() => { throw new Error('Unable to parse request body. Unexpected token at JSON[0]'); });
+
+    eventMock = <SQSEvent> <unknown>{
+      Records: [getValidRecord()],
+    };
+    await handler(eventMock, contextMock);
+
+    expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
+    expect(loggerErrorSpy).nthCalledWith(1, 'Queue item failed: Could not update the following items: unknown - failed to parse input data');
+
+    expect(loggerInfoSpy).toHaveBeenCalledTimes(2);
+    expect(loggerInfoSpy).nthCalledWith(2, 'History queue finished processing. Total items processed: 1, successful: 0, failed: 1.');
+  });
+});

--- a/tests/import-data.test.ts
+++ b/tests/import-data.test.ts
@@ -1,0 +1,106 @@
+import { v4 } from 'uuid';
+import { parsePayload } from '../src/util/import-data';
+
+const mockHistoryEventId = '7db12eed-0c3f-4d27-8221-5699f4e3ea22';
+
+const input = JSON.stringify({
+  Type: 'Notification',
+  MessageId: 'b5c987c9-508b-416d-aff9-38fd81c4fb73',
+  Token: null,
+  Message: JSON.stringify({
+    id: mockHistoryEventId,
+    name: 'Derby Cars Ltd.',
+    email: 'hello@email.com',
+    availability: {
+      isAvailable: false,
+      lastUpdated: '2020-10-09T12:31:46.518Z',
+      endDate: '2020-11-03T14:21:45.000Z',
+      startDate: '2020-10-06T14:21:45.000Z',
+    },
+    token: 'eyJhbGciOiJIUzI1Ni',
+  }),
+});
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('123-456-789'),
+}));
+
+describe('parsePayload()', () => {
+  it('should set the id as a new atfId attribute', () => {
+    const result = parsePayload(input);
+    expect(result).toHaveProperty('atfId');
+    expect(result.atfId).toEqual(mockHistoryEventId);
+  });
+
+  it('should change the id so it is not using the atfId', () => {
+    const result = parsePayload(input);
+    expect(result.id).not.toEqual(mockHistoryEventId);
+  });
+
+  it('should parse a payload as expected', () => {
+    const expected: Record<string, unknown> = {
+      id: v4(),
+      atfId: '7db12eed-0c3f-4d27-8221-5699f4e3ea22',
+      name: 'Derby Cars Ltd.',
+      email: 'hello@email.com',
+      availability: {
+        isAvailable: false,
+        lastUpdated: '2020-10-09T12:31:46.518Z',
+        endDate: '2020-11-03T14:21:45.000Z',
+        startDate: '2020-10-06T14:21:45.000Z',
+      },
+    };
+    const result = parsePayload(input);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('throws an error if payload is missing the id field in the JSON', () => {
+    const requestBody = JSON.stringify({
+      Type: 'Notification',
+      MessageId: 'b5c987c9-508b-416d-aff9-38fd81c4fb73',
+      Token: null,
+      Message: JSON.stringify({
+        name: 'Derby Cars Ltd.',
+        email: 'hello@email.com',
+        availability: {
+          isAvailable: false,
+          lastUpdated: '2020-10-09T12:31:46.518Z',
+          endDate: '2020-11-03T14:21:45.000Z',
+          startDate: '2020-10-06T14:21:45.000Z',
+        },
+        token: 'eyJhbGciOiJIUzI1Ni',
+      }),
+    });
+
+    const t = () => {
+      parsePayload(requestBody);
+    };
+
+    expect(t).toThrow(Error);
+  });
+
+  it('throws an error if payload is missing the availability Message data attribute', () => {
+    const requestBody = JSON.stringify({
+      Type: 'Notification',
+      MessageId: 'b5c987c9-508b-416d-aff9-38fd81c4fb73',
+      Token: null,
+    });
+
+    const t = () => {
+      parsePayload(requestBody);
+    };
+
+    expect(t).toThrow(Error);
+  });
+
+  it('throws an error if payload contains invalid JSON', () => {
+    const requestBody = 'asdf1234!@£$';
+
+    const t = () => {
+      parsePayload(requestBody);
+    };
+
+    expect(t).toThrow(Error);
+  });
+});

--- a/tests/lib/import-data.test.ts
+++ b/tests/lib/import-data.test.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid';
-import { parsePayload } from '../src/util/import-data';
+import { parsePayload } from '../../src/lib/import-data';
 
 const mockHistoryEventId = '7db12eed-0c3f-4d27-8221-5699f4e3ea22';
 

--- a/tests/lib/import-data.test.ts
+++ b/tests/lib/import-data.test.ts
@@ -1,38 +1,22 @@
 import { v4 } from 'uuid';
 import { parsePayload } from '../../src/lib/import-data';
+import * as mocks from '../mocks/validRecord';
 
 const mockHistoryEventId = '7db12eed-0c3f-4d27-8221-5699f4e3ea22';
-
-const input = JSON.stringify({
-  Type: 'Notification',
-  MessageId: 'b5c987c9-508b-416d-aff9-38fd81c4fb73',
-  Token: null,
-  Message: JSON.stringify({
-    id: mockHistoryEventId,
-    name: 'Derby Cars Ltd.',
-    email: 'hello@email.com',
-    availability: {
-      isAvailable: false,
-      lastUpdated: '2020-10-09T12:31:46.518Z',
-      endDate: '2020-11-03T14:21:45.000Z',
-      startDate: '2020-10-06T14:21:45.000Z',
-    },
-    token: 'eyJhbGciOiJIUzI1Ni',
-  }),
-});
+const input = mocks.getEventRecordItem(mockHistoryEventId);
 
 jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('123-456-789'),
 }));
 
 describe('parsePayload()', () => {
-  it('should set the id as a new atfId attribute', () => {
+  it('should create a new atfId attribute with the value of the old record id', () => {
     const result = parsePayload(input);
     expect(result).toHaveProperty('atfId');
     expect(result.atfId).toEqual(mockHistoryEventId);
   });
 
-  it('should change the id so it is not using the atfId', () => {
+  it('should set a new item id so it is not using the atfId for the db key column', () => {
     const result = parsePayload(input);
     expect(result.id).not.toEqual(mockHistoryEventId);
   });
@@ -73,11 +57,11 @@ describe('parsePayload()', () => {
       }),
     });
 
-    const t = () => {
+    const result = () => {
       parsePayload(requestBody);
     };
 
-    expect(t).toThrow(Error);
+    expect(result).toThrow(Error);
   });
 
   it('throws an error if payload is missing the availability Message data attribute', () => {
@@ -87,20 +71,20 @@ describe('parsePayload()', () => {
       Token: null,
     });
 
-    const t = () => {
+    const result = () => {
       parsePayload(requestBody);
     };
 
-    expect(t).toThrow(Error);
+    expect(result).toThrow(Error);
   });
 
   it('throws an error if payload contains invalid JSON', () => {
     const requestBody = 'asdf1234!@£$';
 
-    const t = () => {
+    const result = () => {
       parsePayload(requestBody);
     };
 
-    expect(t).toThrow(Error);
+    expect(result).toThrow(Error);
   });
 });

--- a/tests/mocks/invalidRecord.ts
+++ b/tests/mocks/invalidRecord.ts
@@ -1,0 +1,35 @@
+export function getInvalidRecord() : Record<string, unknown> {
+  return {
+    messageId: '4f80239a-03c9-4fce-d68a-104001cbc5cb',
+    receiptHandle: 'gvjxhsgayqxjneypkfnbfyvnvoeajirwkwlgmoioigyqijuqaembinhjsrkpaxvyhp',
+    mD5OfBody: 'fb4823f6e5532530878d696331b20f3c',
+    // eslint-disable-next-line max-len
+    body: getEventRecordItem(),
+    attributes: {
+      SenderId: 'AIDAIT2UOQQY3AUEKVGXU',
+      SentTimestamp: '1616672505599',
+      ApproximateReceiveCount: '1',
+      ApproximateFirstReceiveTimestamp: '1616672530339',
+    },
+  };
+}
+
+export function getEventRecordItem(mockHistoryEventId = '123-123-123') :string {
+  return JSON.stringify({
+    Type: 'Notification',
+    MessageId: 'b5c987c9-508b-416d-aff9-38fd81c4fb73',
+    Token: null,
+    Message: JSON.stringify({
+      id: mockHistoryEventId,
+      name: 'Derby Cars Ltd.',
+      email: 'hello@email.com',
+      availability: {
+        isAvailable: false,
+        lastUpdated: '2020-10-09T12:31:46.518Z',
+        endDate: '2020-11-03T14:21:45.000Z',
+        startDate: '2020-10-06T14:21:45.000Z',
+      },
+      token: 'eyJhbGciOiJIUzI1Ni',
+    }),
+  });
+}

--- a/tests/mocks/validParsedRecord.ts
+++ b/tests/mocks/validParsedRecord.ts
@@ -1,9 +1,9 @@
 import { HistoryData } from '../../src/lib/import-data';
 
-export function getExpectedEventItem(id = '456-456-456'): HistoryData {
+export function getExpectedEventItem(id = '456-456-456', atfId = '7db12eed-0c3f-4d27-8221-5699f4e3ea22'): HistoryData {
   const item = {
     id,
-    atfId: '7db12eed-0c3f-4d27-8221-5699f4e3ea22',
+    atfId,
     name: 'Derby Cars Ltd.',
     email: 'hello@email.com',
     availability: {

--- a/tests/mocks/validParsedRecord.ts
+++ b/tests/mocks/validParsedRecord.ts
@@ -1,0 +1,17 @@
+import { HistoryData } from '../../src/lib/import-data';
+
+export function getExpectedEventItem(id = '456-456-456'): HistoryData {
+  const item = {
+    id,
+    atfId: '7db12eed-0c3f-4d27-8221-5699f4e3ea22',
+    name: 'Derby Cars Ltd.',
+    email: 'hello@email.com',
+    availability: {
+      isAvailable: 'false',
+      lastUpdated: '2020-10-09T12:31:46.518Z',
+      endDate: '2020-11-03T14:21:45.000Z',
+      startDate: '2020-10-06T14:21:45.000Z',
+    },
+  };
+  return item;
+}

--- a/tests/mocks/validRecord.ts
+++ b/tests/mocks/validRecord.ts
@@ -1,9 +1,8 @@
 export function getValidRecord() : Record<string, unknown> {
   return {
-    messageId: '4f80239a-03c9-4fce-d68a-104001cbc5cb',
+    messageId: validMessageId,
     receiptHandle: 'gvjxhsgayqxjneypkfnbfyvnvoeajirwkwlgmoioigyqijuqaembinhjsrkpaxvyhp',
     mD5OfBody: 'fb4823f6e5532530878d696331b20f3c',
-    // eslint-disable-next-line max-len
     body: getEventRecordItem(),
     attributes: {
       SenderId: 'AIDAIT2UOQQY3AUEKVGXU',
@@ -13,6 +12,8 @@ export function getValidRecord() : Record<string, unknown> {
     },
   };
 }
+
+export const validMessageId = '4f80239a-03c9-4fce-d68a-104001cbc5cb';
 
 export function getEventRecordItem(mockHistoryEventId = '123-123-123') :string {
   return JSON.stringify({

--- a/tests/mocks/validRecord.ts
+++ b/tests/mocks/validRecord.ts
@@ -1,0 +1,35 @@
+export function getValidRecord() : Record<string, unknown> {
+  return {
+    messageId: '4f80239a-03c9-4fce-d68a-104001cbc5cb',
+    receiptHandle: 'gvjxhsgayqxjneypkfnbfyvnvoeajirwkwlgmoioigyqijuqaembinhjsrkpaxvyhp',
+    mD5OfBody: 'fb4823f6e5532530878d696331b20f3c',
+    // eslint-disable-next-line max-len
+    body: getEventRecordItem(),
+    attributes: {
+      SenderId: 'AIDAIT2UOQQY3AUEKVGXU',
+      SentTimestamp: '1616672505599',
+      ApproximateReceiveCount: '1',
+      ApproximateFirstReceiveTimestamp: '1616672530339',
+    },
+  };
+}
+
+export function getEventRecordItem(mockHistoryEventId = '123-123-123') :string {
+  return JSON.stringify({
+    Type: 'Notification',
+    MessageId: 'b5c987c9-508b-416d-aff9-38fd81c4fb73',
+    Token: null,
+    Message: JSON.stringify({
+      id: mockHistoryEventId,
+      name: 'Derby Cars Ltd.',
+      email: 'hello@email.com',
+      availability: {
+        isAvailable: false,
+        lastUpdated: '2020-10-09T12:31:46.518Z',
+        endDate: '2020-11-03T14:21:45.000Z',
+        startDate: '2020-10-06T14:21:45.000Z',
+      },
+      token: 'eyJhbGciOiJIUzI1Ni',
+    }),
+  });
+}

--- a/tests/util/logger.test.ts
+++ b/tests/util/logger.test.ts
@@ -1,0 +1,54 @@
+import type { Context } from 'aws-lambda';
+import { createLogger, Logger } from '../../src/util/logger';
+import * as mocks from '../mocks/validRecord';
+
+jest.unmock('../../src/util/logger');
+
+describe('Test logger', () => {
+  test('createLogger() via context lambdaId should return a logger object with the correct logFormat', () => {
+    const apiRequestId: string = mocks.validMessageId;
+    const contextMock: Context = <Context> { awsRequestId: apiRequestId };
+
+    const logger: Logger = createLogger(contextMock);
+
+    expect(logger.logFormat).toBe(
+      `{ "apiRequestId": "${apiRequestId}", "message": "%s" }`,
+    );
+  });
+
+  test('logger.debug() calls console.debug() with expected parameters', () => {
+    const logger: Logger = new Logger('');
+    console.debug = jest.fn();
+
+    logger.debug('hello');
+
+    expect(console.debug).toHaveBeenCalledWith(logger.logFormat, 'hello');
+  });
+
+  test('logger.info() calls console.info() with expected parameters', () => {
+    const logger: Logger = new Logger('');
+    console.info = jest.fn();
+
+    logger.info('hello');
+
+    expect(console.info).toHaveBeenCalledWith(logger.logFormat, 'hello');
+  });
+
+  test('logger.warn() calls console.warn() with expected parameters', () => {
+    const logger: Logger = new Logger('');
+    console.warn = jest.fn();
+
+    logger.warn('hello');
+
+    expect(console.warn).toHaveBeenCalledWith(logger.logFormat, 'hello');
+  });
+
+  test('logger.error() calls console.error() with expected parameters', () => {
+    const logger: Logger = new Logger('');
+    console.error = jest.fn();
+
+    logger.error('hello');
+
+    expect(console.error).toHaveBeenCalledWith(logger.logFormat, 'hello');
+  });
+});

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,9 +1,7 @@
 const path = require('path');
 const AwsSamPlugin = require('aws-sam-webpack-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
 
 const awsSamPlugin = new AwsSamPlugin({ vscodeDebug: false });
-const LAMBDA_NAME = 'SQSHistoryFunction'; // must correspond to lambda name in template.yml
 
 module.exports = {
   // Loads the entry object from the AWS::Serverless::Function resources in your
@@ -40,11 +38,6 @@ module.exports = {
 
   // Add the AWS SAM Webpack plugin
   plugins: [
-    awsSamPlugin,
-    new CopyPlugin({
-      patterns: [
-        { from: './.env', to: `.aws-sam/build/${LAMBDA_NAME}/` },
-      ],
-    }),
+    awsSamPlugin
   ],
 };

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,7 +1,17 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const CopyPlugin = require('copy-webpack-plugin');
+
+const LAMBDA_NAME = 'SQSHistoryFunction'; // must correspond to lambda name in template.yml
 
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'source-map',
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: './.env', to: `.aws-sam/build/${LAMBDA_NAME}/` },
+      ],
+    }),
+  ],
 });

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -6,7 +6,8 @@ const branchName = require('current-git-branch');
 
 const LAMBDA_NAME = 'SQSHistoryFunction';
 const OUTPUT_FOLDER = './dist'
-const BUILD_VERSION = branchName().replace("/","-");
+const REPO_NAME = 'hvt-atf-history';
+const BRANCH_NAME = branchName().replace("/","-");
 
 class BundlePlugin {
   constructor(params) {
@@ -53,17 +54,21 @@ class BundlePlugin {
   }
 };
 
-module.exports = merge(common, {
-  mode: 'production',
-  plugins: [
-    new BundlePlugin({
-      archives: [
-        {
-          inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
-          outputPath: `${OUTPUT_FOLDER}`,
-          outputName: `HVT-${LAMBDA_NAME}-${BUILD_VERSION}`,
-        }
-      ],
-    }),
-  ],
-});
+
+module.exports = env => {
+  let commit = env ? env.commit ? env.commit : 'local' : 'local' ;
+  return merge(common, {
+    mode: 'production',
+    plugins: [
+      new BundlePlugin({
+        archives: [
+          {
+            inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
+            outputPath: `${OUTPUT_FOLDER}`,
+            outputName: `${REPO_NAME}-${BRANCH_NAME}-${commit}`,
+          }
+        ],
+      }),
+    ],
+  });
+};


### PR DESCRIPTION
## Description

- Handler takes SNS message and saves it to table
- Helper parses the SNS history data into JSON
- Service sends the data to the history table
- Log out failures and skip failing items and log count of
successful items saved
- closes Ticket !BL-11682

Related issue: [BL-11682](https://jira.dvsacloud.uk/browse/BL-11682)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added test coverage to the JIRA ticket
- [x] Commit contains the JIRA ticket number